### PR TITLE
feat: expose role and transcriptType on Transcript event

### DIFF
--- a/app/src/main/java/ai/vapi/android/Vapi.kt
+++ b/app/src/main/java/ai/vapi/android/Vapi.kt
@@ -51,7 +51,11 @@ public class Vapi(
     sealed class Event {
         object CallDidStart : Event()
         object CallDidEnd : Event()
-        data class Transcript(val text: String) : Event()
+        data class Transcript(
+            val text: String,
+            val role: String,
+            val transcriptType: String,
+        ) : Event()
         data class FunctionCall(val name: String, val parameters: Map<String, Any>) : Event()
         data class SpeechUpdate(val status: String, val role: String) : Event()
         object UserInterrupted: Event()
@@ -338,7 +342,11 @@ public class Vapi(
                         )
                     }
                     "hang" -> Event.Hang
-                    "transcript" -> Event.Transcript(jsonObject["transcript"] as String)
+                    "transcript" -> Event.Transcript(
+                        text = jsonObject["transcript"] as String,
+                        role = (jsonObject["role"] as? String) ?: "assistant",
+                        transcriptType = (jsonObject["transcriptType"] as? String) ?: "partial",
+                    )
                     "speech-update" -> Event.SpeechUpdate(
                         status = jsonObject["status"] as String,
                         role = jsonObject["role"] as String


### PR DESCRIPTION
The Vapi WebSocket sends `role` ("user" or "assistant") and `transcriptType` ("partial" or "final") on transcript messages, but the SDK was discarding them. This makes it impossible to distinguish user speech from assistant speech in real-time.

This change adds both fields to `Event.Transcript` so consumers can identify the speaker and finality without relying on the delayed `ConversationUpdate` event.